### PR TITLE
Document optional extras and make tests resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,35 @@ A Dynamic Energy Budget modelling framework written in Julia.
 This is a generalised DEB model developed for plant modelling, but can be used to model any kind of organism.
 
 This models can also be run in microclimates provided by the NicheMapR R package
-using [Microclimate.jl](https://github.com/rafaqz/Microclimate.jl), 
-and can use wide a range of photosynthesis and stomatal conductance formulations 
+using [Microclimate.jl](https://github.com/rafaqz/Microclimate.jl),
+and can use wide a range of photosynthesis and stomatal conductance formulations
 from [Photosynthesis.jl](https://github.com/rafaqz/Photosynthesis.jl).
 
 See scripts at https://github.com/rafaqz/DEBplant for a live user interface and plotting examples. This package and Photosynthesis.jl are not officially registered, so build a project using DEBplant as the package versions are locked in the Manifest.toml.
 
-If you need this package to be registered, make an issue and request it! I am not currently working on DEB models and have many other packages competing for my time. If there is a project that wishes to use it, I will gladly help get things working for you. 
+## Development and testing
+
+The automated tests and documentation build rely on the unregistered
+`Microclimate.jl` and `Photosynthesis.jl` packages.  Before running the test
+suite or generating the documentation, develop pinned revisions of these
+packages in your active environment:
+
+```julia
+using Pkg
+Pkg.develop(url = "https://github.com/rafaqz/Microclimate.jl", rev = "d9a03c42d101fa3f4de6fcbadc9c04a5c53ffaa8")
+Pkg.develop(url = "https://github.com/rafaqz/Photosynthesis.jl", rev = "0469a84a201898a37cf542292d8722f8ed05e49c")
+```
+
+Once the extras are available you can run
+
+```julia
+Pkg.test()
+```
+
+The test harness will skip the Microclimate/Photosynthesis dependent suites if
+these packages cannot be downloaded so that the remaining tests can still run.
+
+If you need this package to be registered, make an issue and request it! I am not currently working on DEB models and have many other packages competing for my time. If there is a project that wishes to use it, I will gladly help get things working for you.
 
 
 Code is largely adapted from the original [DEBtool](https://github.com/add-my-pet/DEBtool_M)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DynamicEnergyBudgets = "6ffd65d2-8b0b-5314-9c5b-6efe83b0316c"
+
+[extras]
 Microclimate = "e0eb800d-4a9f-54ae-b0f8-217228d9d7c3"
 Photosynthesis = "5e10c064-2706-53a3-a67d-d473e313a663"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,47 @@
-using Documenter, DocStringExtensions, DynamicEnergyBudgets, Microclimate, Photosynthesis
+using Documenter, DocStringExtensions, DynamicEnergyBudgets
+import Pkg
+
+struct ExtraSpec
+    name::Symbol
+    url::String
+    rev::String
+end
+
+const MICROCLIMATE_SPEC = ExtraSpec(
+    :Microclimate,
+    "https://github.com/rafaqz/Microclimate.jl",
+    "d9a03c42d101fa3f4de6fcbadc9c04a5c53ffaa8",
+)
+const PHOTOSYNTHESIS_SPEC = ExtraSpec(
+    :Photosynthesis,
+    "https://github.com/rafaqz/Photosynthesis.jl",
+    "0469a84a201898a37cf542292d8722f8ed05e49c",
+)
+
+function maybe_import_extra(spec::ExtraSpec)
+    pkg_name = String(spec.name)
+    if Base.find_package(pkg_name) === nothing
+        try
+            Pkg.develop(Pkg.PackageSpec(url = spec.url, rev = spec.rev))
+        catch err
+            @warn "Unable to download $(pkg_name) from $(spec.url); documentation that references it may be incomplete." exception =
+                (err, catch_backtrace()) suggestion = "Pkg.develop(url = \"$(spec.url)\", rev = \"$(spec.rev)\")"
+            return false
+        end
+    end
+
+    try
+        @eval import $(spec.name)
+        return true
+    catch err
+        @warn "$(pkg_name) is unavailable; documentation that references it may be incomplete." exception =
+            (err, catch_backtrace()) suggestion = "Pkg.develop(url = \"$(spec.url)\", rev = \"$(spec.rev)\")"
+        return false
+    end
+end
+
+const HAS_MICROCLIMATE = maybe_import_extra(MICROCLIMATE_SPEC)
+const HAS_PHOTOSYNTHESIS = maybe_import_extra(PHOTOSYNTHESIS_SPEC)
 
 makedocs(
     modules = [DynamicEnergyBudgets],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,61 @@
-using SafeTestsets 
+using SafeTestsets
+import Pkg
+
+struct ExtraSpec
+    name::Symbol
+    url::String
+    rev::String
+end
+
+const MICROCLIMATE_SPEC = ExtraSpec(
+    :Microclimate,
+    "https://github.com/rafaqz/Microclimate.jl",
+    "d9a03c42d101fa3f4de6fcbadc9c04a5c53ffaa8",
+)
+const PHOTOSYNTHESIS_SPEC = ExtraSpec(
+    :Photosynthesis,
+    "https://github.com/rafaqz/Photosynthesis.jl",
+    "0469a84a201898a37cf542292d8722f8ed05e49c",
+)
+
+function ensure_extra(spec::ExtraSpec)
+    pkg_name = String(spec.name)
+    if Base.find_package(pkg_name) === nothing
+        try
+            Pkg.develop(Pkg.PackageSpec(url = spec.url, rev = spec.rev))
+        catch err
+            @warn "Unable to download $(pkg_name) from $(spec.url); tests requiring it will be skipped." exception =
+                (err, catch_backtrace()) suggestion = "Pkg.develop(url = \"$(spec.url)\", rev = \"$(spec.rev)\")"
+            return false
+        end
+    end
+
+    try
+        @eval import $(spec.name)
+        return true
+    catch err
+        @warn "$(pkg_name) is unavailable; tests requiring it will be skipped." exception = (err, catch_backtrace()) suggestion =
+            "Pkg.develop(url = \"$(spec.url)\", rev = \"$(spec.rev)\")"
+        return false
+    end
+end
+
+const HAS_MICROCLIMATE = ensure_extra(MICROCLIMATE_SPEC)
+const HAS_PHOTOSYNTHESIS = ensure_extra(PHOTOSYNTHESIS_SPEC)
 
 @safetestset "setup" begin include("setup.jl") end
 @safetestset "temperature correction" begin include("tempcorrection.jl") end
 @safetestset "math" begin include("math.jl") end
-@safetestset "environment" begin include("environment.jl") end
-@safetestset "balance" begin include("balance.jl") end
-@safetestset "diffeq" begin include("diffeq.jl") end
+
+if HAS_MICROCLIMATE && HAS_PHOTOSYNTHESIS
+    @safetestset "environment" begin include("environment.jl") end
+    @safetestset "balance" begin include("balance.jl") end
+else
+    @info "Skipping tests that require Microclimate.jl and Photosynthesis.jl." microclimate = HAS_MICROCLIMATE photosynthesis = HAS_PHOTOSYNTHESIS
+end
+
+if HAS_MICROCLIMATE
+    @safetestset "diffeq" begin include("diffeq.jl") end
+else
+    @info "Skipping tests that require Microclimate.jl." microclimate = HAS_MICROCLIMATE
+end


### PR DESCRIPTION
## Summary
- document how to develop Microclimate.jl and Photosynthesis.jl before testing
- have the test suite attempt to develop the optional extras and skip dependent sets if they remain unavailable
- treat Microclimate.jl and Photosynthesis.jl as optional extras for the docs build

## Testing
- not run (Julia unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc9ed163ac832395ece1c4511740fd